### PR TITLE
lib: Add Home screen

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,0 +1,22 @@
+import 'package:cms_android/screens/home.dart';
+import 'package:cms_android/screens/login_screen.dart';
+import 'package:flutter/material.dart';
+
+class CMS extends StatefulWidget {
+  @override
+  _CMS createState() => _CMS();
+}
+
+class _CMS extends State<CMS> {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: HomePage(),
+      initialRoute: '/login',
+      routes: {
+        '/login': (BuildContext context) => LoginScreen()
+      },
+      debugShowCheckedModeBanner: false,
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,16 +1,4 @@
-import 'package:cms_android/screens/login_screen.dart';
+import 'package:cms_android/app.dart';
 import 'package:flutter/material.dart';
 
-void main() => runApp(MyApp());
-
-class MyApp extends StatelessWidget {
-  // This widget is the root of your application.
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'amFOSS CMS',
-      debugShowCheckedModeBanner: false,
-      home: LoginScreen(),
-    );
-  }
-}
+void main() => runApp(CMS());

--- a/lib/screens/attendance.dart
+++ b/lib/screens/attendance.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class Attendance extends StatefulWidget {
+  @override
+  _Attendance createState() => _Attendance();
+}
+
+class _Attendance extends State<Attendance> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        padding: EdgeInsets.only(left: 10.0, top: 30.0),
+        child: Column(
+          children: <Widget>[
+            Text('Attendance')
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -1,0 +1,39 @@
+import 'package:cms_android/screens/attendance.dart';
+import 'package:cms_android/screens/profile.dart';
+import 'package:cms_android/screens/status_update.dart';
+import 'package:flutter/material.dart';
+
+class HomePage extends StatefulWidget {
+  @override
+  _HomePage createState() => _HomePage();
+}
+
+class _HomePage extends State<HomePage> {
+  int _currentIndex = 0;
+  final List<Widget> _children = [Attendance(), Profile(), StatusUpdate()];
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: _children[_currentIndex],
+      bottomNavigationBar: BottomNavigationBar(
+        items: <BottomNavigationBarItem>[
+          BottomNavigationBarItem(
+            icon: Icon(Icons.playlist_add_check),
+            title: Text("Attendance"),
+          ),
+          BottomNavigationBarItem(
+              icon: Icon(Icons.person), title: Text("Profile")),
+          BottomNavigationBarItem(
+              icon: Icon(Icons.check_box), title: Text("Status")),
+        ],
+        onTap: onTabTapped,
+      ),
+    );
+  }
+
+  void onTabTapped(int index) {
+    setState(() {
+      _currentIndex = index;
+    });
+  }
+}

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,3 +1,4 @@
+import 'package:cms_android/screens/home.dart';
 import 'package:cms_android/utilities/constants.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -81,9 +82,7 @@ class _LoginScreenState extends State<LoginScreen> {
               hintStyle: kHintTextStyle,
               suffixIcon: IconButton(
                 icon: Icon(
-                  passwordVisible
-                      ? Icons.visibility
-                      : Icons.visibility_off,
+                  passwordVisible ? Icons.visibility : Icons.visibility_off,
                   color: Colors.black,
                 ),
                 onPressed: () {
@@ -146,7 +145,6 @@ class _LoginScreenState extends State<LoginScreen> {
       width: double.infinity,
       child: RaisedButton(
         elevation: 5.0,
-        onPressed: () => print('Login Button Pressed'),
         padding: EdgeInsets.all(15.0),
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(30.0),
@@ -162,6 +160,7 @@ class _LoginScreenState extends State<LoginScreen> {
             fontFamily: 'OpenSans',
           ),
         ),
+        onPressed: () => Navigator.pop(context)
       ),
     );
   }
@@ -216,6 +215,7 @@ class _LoginScreenState extends State<LoginScreen> {
               ),
               Container(
                 height: double.infinity,
+                //TODO: Remove ScrollView
                 child: SingleChildScrollView(
                   physics: AlwaysScrollableScrollPhysics(),
                   padding: EdgeInsets.symmetric(

--- a/lib/screens/profile.dart
+++ b/lib/screens/profile.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class Profile extends StatefulWidget {
+  @override
+  _Profile createState() => _Profile();
+}
+
+class _Profile extends State<Profile> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        padding: EdgeInsets.only(left: 10.0, top: 30.0),
+        child: Column(
+          children: <Widget>[
+            Text('Profile')
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/status_update.dart
+++ b/lib/screens/status_update.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class StatusUpdate extends StatefulWidget {
+  @override
+  _StatusUpdate createState() => _StatusUpdate();
+}
+
+class _StatusUpdate extends State<StatusUpdate> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Container(
+        padding: EdgeInsets.only(left: 10.0, top: 30.0),
+        child: Column(
+          children: <Widget>[
+            Text('Status Update')
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -74,6 +74,41 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  graphql:
+    dependency: transitive
+    description:
+      name: graphql
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.0"
+  graphql_flutter:
+    dependency: "direct main"
+    description:
+      name: graphql_flutter
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.0"
+  graphql_parser:
+    dependency: transitive
+    description:
+      name: graphql_parser
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.4"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.12.0+4"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.1.3"
   image:
     dependency: transitive
     description:
@@ -95,6 +130,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.8"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.9.6+3"
   path:
     dependency: transitive
     description:
@@ -102,6 +144,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.6.4"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.5.1"
   pedantic:
     dependency: transitive
     description:
@@ -116,6 +165,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.4.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.2.1"
   quiver:
     dependency: transitive
     description:
@@ -123,6 +179,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.5"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.22.6"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -177,6 +240,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.6"
+  uuid_enhanced:
+    dependency: transitive
+    description:
+      name: uuid_enhanced
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.2"
   vector_math:
     dependency: transitive
     description:
@@ -184,6 +254,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.8"
+  websocket:
+    dependency: transitive
+    description:
+      name: websocket
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.5"
   xml:
     dependency: transitive
     description:
@@ -193,3 +270,4 @@ packages:
     version: "3.5.0"
 sdks:
   dart: ">=2.4.0 <3.0.0"
+  flutter: ">=1.10.0 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.2
+  graphql_flutter: ^2.1.0
 
 dev_dependencies:
   flutter_test:

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -5,15 +5,14 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
+import 'package:cms_android/app.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import 'package:cms_android/main.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(MyApp());
+    await tester.pumpWidget(CMS());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
lib/app.dart:
	Add MaterialApp and initialize routes
lib/main.dart:
	Move MaterialApp to app.dart
lib/screens/attendance.dart:
	Add empty screen
lib/screens/home.dart:
	Add bottom bar
lib/screens/login_screen.dart:
	Modify navigation
lib/screens/profile.dart:
	Add empty screen
lib/screens/status_update.dart:
	Add empty screen
pubspec.yaml:
	Add support for GraphQL